### PR TITLE
Fixed no rule for target bug, Cleaned up INSTALL.md compile instr.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -711,16 +711,11 @@ if(WIN32)
 
 endif(WIN32)
 
+add_executable (yap-bin ${CONSOLE_SOURCES})
 if (NOT ANDROID)
-add_executable (yap-bin ${CONSOLE_SOURCES} yap)
-
-set_target_properties (yap-bin PROPERTIES OUTPUT_NAME yap)
+   set_target_properties (yap-bin PROPERTIES OUTPUT_NAME yap)
 else()
-add_executable (yap-bin ${CONSOLE_SOURCES} yap)
-
-set_target_properties (yap-bin PROPERTIES OUTPUT_NAME yapi)
-
-
+	set_target_properties (yap-bin PROPERTIES OUTPUT_NAME yapi)
 endif()
 
 target_link_libraries(yap-bin libYap )

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,20 +11,21 @@ Compiling YAP {#CompilingYAP}
 
 To compile YAP it should be sufficient to:
 
-2 create a directory, say `Build` and `cd` to the directory (`cd Build`).
+0: Install a version of `cmake` 3.0 or above, if you don't have it, and add it to your path, you can find it here: https://cmake.org/
+	* OSX: Create a symbolic link to the command line executables in
+      /usr/local/bin (which should be on your path) with `sudo ln -s /Applications/CMake.app/Contents/bin/* /usr/local/bin/`
 
-  obs: avoid compiling YAP in the src directory, some packages do not allow for that.
+1: Create a directory, say `Build` and `cd` to the directory (`cd Build`).
+	* Avoid compiling YAP in the src directory, some packages do not allow for that.
 
-1 run `cmake`, ideally using a cmake above 3.0.
+2: Run `cmake ../` from within `Build` (or equivalent)
 
-2 `make`.
+3: Run `make` from within `Build` (or equivalent)
 
-3 If the compilation succeeds, try `./yap`.
+4: If the compilation succeeds, try `./yap`.  This is your executable. 
 
-4  If you feel satisfied with the result, do `make install`.
-
-5 In most systems you will need to be superuser in order to do
-    `make install` and `make info` on the standard directories.
+5: If you feel satisfied with the result, do `make install`.
+	* In most systems you will need to be superuser in order to do `make install` and `make info` on the standard directories.
 
 Tuning the Functionality of YAP
 -------------------------------


### PR DESCRIPTION
Cleaned up the INSTALL.md installation instructions, and realized latest code would not build.  So I patched the CMakeLists.txt file fixing the failed build bug of ‘no rule for target’ error message.