### PR TITLE
[WIP] Restore Thread Support

### DIFF
--- a/C/absmi.c
+++ b/C/absmi.c
@@ -364,7 +364,7 @@ static int interrupt_wake_up(Term cut_t, yamop *p USES_REGS) {
   if (p) {
     Term ts[2];
     ts[0] = tg;
-    Term regs = save_xregs(p PASS_REGS);
+    Term regs = save_xregs(p);
     ts[1] = Yap_MkApplTerm(FunctorRestoreRegs1, 1, &regs);
     if (tg == TermTrue) {
 	tg =ts[1];
@@ -392,7 +392,7 @@ static int interrupt_wake_up(Term cut_t, yamop *p USES_REGS) {
   ARG1 = t1;
   ARG2 = t2;
   CACHE_A1();
-  return Yap_execute_pred(pe, NULL, true) ?
+  return Yap_execute_pred(pe, NULL, true PASS_REGS) ?
 	  INT_HANDLER_RET_JMP :
 	  INT_HANDLER_FAIL;
 

--- a/C/adtdefs.c
+++ b/C/adtdefs.c
@@ -758,7 +758,8 @@ Atom Yap_LookupAtomWithLength(const char *atom,
       return NIL;
     }
     INIT_LOCK(p->PELock);
-    p->StatisticsForPred = NULL : p->KindOfPE = PEProp;
+    p->StatisticsForPred = NULL;
+    p->KindOfPE = PEProp;
     p->ArityOfPE = ap->ArityOfPE;
     p->FirstClause = p->LastClause = NULL;
     p->NOfClauses = 0;
@@ -1267,6 +1268,7 @@ Atom Yap_LookupAtomWithLength(const char *atom,
   }
 
   const char *IndicatorOfPred(PredEntry *pe) {
+    CACHE_REGS
     const char *mods;
     Atom at;
     arity_t arity;

--- a/C/alloc.c
+++ b/C/alloc.c
@@ -78,6 +78,7 @@ static char SccsId[] = "%W% %G%";
 int write_malloc = 0;
 
 void *my_malloc(size_t sz) {
+  CACHE_REGS
   void *p;
 
   p = malloc(sz);
@@ -106,6 +107,7 @@ void *my_realloc(void *ptr, size_t sz) {
 }
 
 void my_free(void *p) {
+  CACHE_REGS
   // printf("f %p\n",p);
   if (Yap_do_low_level_trace)
     fprintf(stderr, "- %p\n @%p %ld\n", p, TR, (long int)(LCL0 - (CELL *)B) );
@@ -1658,9 +1660,13 @@ typedef struct TextBuffer_manager {
   int lvl;
 } text_buffer_t;
 
-int AllocLevel(void) { return LOCAL_TextBuffer->lvl; }
+int AllocLevel(void) {
+  CACHE_REGS
+  return LOCAL_TextBuffer->lvl;
+}
 //	void pop_text_stack(int i) { LOCAL_TextBuffer->lvl = i; }
 void insert_block(struct mblock *o) {
+  CACHE_REGS
   int lvl = o->lvl;
   o->prev = LOCAL_TextBuffer->last[lvl];
   if (o->prev) {
@@ -1675,6 +1681,7 @@ void insert_block(struct mblock *o) {
 }
 
  void release_block(struct mblock *o) {
+  CACHE_REGS
   int lvl = o->lvl;
   if (LOCAL_TextBuffer->first[lvl] == o) {
     if (LOCAL_TextBuffer->last[lvl] == o) {
@@ -1698,7 +1705,7 @@ int push_text_stack__(USES_REGS1) {
   return i;
 }
 
-int pop_text_stack__(int i) {
+int pop_text_stack__(int i USES_REGS) {
   int lvl = LOCAL_TextBuffer->lvl;
   while (lvl >= i) {
     struct mblock *p = LOCAL_TextBuffer->first[lvl];
@@ -1715,7 +1722,7 @@ int pop_text_stack__(int i) {
   return lvl;
 }
 
-void *pop_output_text_stack__(int i, const void *export) {
+void *pop_output_text_stack__(int i, const void *export USES_REGS) {
   int lvl = LOCAL_TextBuffer->lvl;
   bool found = false;
   while (lvl >= i) {
@@ -1841,6 +1848,7 @@ void *Yap_InitTextAllocator(void) {
 
 
  bool Yap_get_scratch_buf(scratch_struct_t *handle, size_t nof, size_t each) {
+   CACHE_REGS
    handle->n_of = nof;
    handle->size_of = each;
    if (!handle->data) {
@@ -1868,6 +1876,7 @@ bool Yap_realloc_scratch_buf(scratch_struct_t *handle, size_t nof) {
  }
 
    bool Yap_release_scratch_buf(scratch_struct_t *handle) {
+     CACHE_REGS
      if (handle->is_thread_scratch_buf &&
 	 handle->data == LOCAL_WorkerBuffer.data) {
        LOCAL_WorkerBuffer.in_use= false;

--- a/C/arith0.c
+++ b/C/arith0.c
@@ -253,6 +253,7 @@ static InitConstEntry InitConstTab[] = {
 void
 Yap_InitConstExps(void)
 {
+  CACHE_REGS
   unsigned int    i;
   ExpEntry       *p;
 

--- a/C/arith1.c
+++ b/C/arith1.c
@@ -1032,6 +1032,7 @@ static Int p_unary_op_as_integer(USES_REGS1) { /* X is Y	 */
 }
 
 void Yap_InitUnaryExps(void) {
+  CACHE_REGS
   unsigned int i;
   ExpEntry *p;
 

--- a/C/arith2.c
+++ b/C/arith2.c
@@ -650,6 +650,7 @@ p_power(Term t1, Term t2 USES_REGS)
 static inline Int
 ipow(Int x, Int p)
 {
+  CACHE_REGS
   Int r;
 
   if (p == 0) return ((CELL)1);
@@ -657,7 +658,7 @@ ipow(Int x, Int p)
   if(p < 0)
     return (-p % 2) ? x : ((CELL)1);
   Int px =  x<0 ?-x : x;
-  Int nbits = Yap_msb(px) * p;
+  Int nbits = Yap_msb(px PASS_REGS) * p;
   if (nbits > sizeof(CELL)*8-3)
     return 0;
   r = ((CELL)1);
@@ -1290,6 +1291,7 @@ Yap_NameOfBinaryOp(int i)
 void
 Yap_InitBinaryExps(void)
 {
+  CACHE_REGS
   unsigned int    i;
   ExpEntry       *p;
 

--- a/C/atomic.c
+++ b/C/atomic.c
@@ -710,9 +710,9 @@ static Int number_chars(USES_REGS1) {
   if (IsNonVarTerm(t1)) {
     if (IsVarTerm(t2)) {
       pop_text_stack(l);
-      return Yap_unify(ARG2, Yap_NumberToListOfAtoms(t1));
+      return Yap_unify(ARG2, Yap_NumberToListOfAtoms(t1 PASS_REGS));
   } else {
-    Term t2 = Yap_ListToNumber( Deref(ARG2) );
+    Term t2 = Yap_ListToNumber( Deref(ARG2) PASS_REGS);
     pop_text_stack(l);
     if (t1&& t2) {
           return Yap_unify(t1, t2);
@@ -857,9 +857,9 @@ static Int number_codes(USES_REGS1) {
   if (IsNonVarTerm(t1)) {
     if (IsVarTerm(t2)) {
       pop_text_stack(l);
-      return Yap_unify(ARG2, Yap_NumberToListOfCodes(t1));
+      return Yap_unify(ARG2, Yap_NumberToListOfCodes(t1 PASS_REGS));
   } else {
-    Term t2 = Yap_ListToNumber( Deref(ARG2) );
+    Term t2 = Yap_ListToNumber( Deref(ARG2) PASS_REGS);
     pop_text_stack(l);
     if (t1&& t2) {
           return Yap_unify(t1, t2);
@@ -1326,7 +1326,7 @@ restart_aux:
   if (*tailp != TermNil) {
     LOCAL_Error_TYPE = TYPE_ERROR_LIST;
   } else {
-    seq_tv_t *inpv = (seq_tv_t *)Malloc(n * sizeof(seq_tv_t)), out;
+    seq_tv_t *inpv = (seq_tv_t *)Malloc(n * sizeof(seq_tv_t) PASS_REGS), out;
     int i = 0;
     Atom at;
 
@@ -1375,8 +1375,8 @@ restart_aux:
   if (*tailp != TermNil) {
     LOCAL_Error_TYPE = TYPE_ERROR_LIST;
   } else {
-    seq_tv_t *inpv = (seq_tv_t *)Malloc(n * sizeof(seq_tv_t));
-    seq_tv_t *out = (seq_tv_t *)Malloc(sizeof(seq_tv_t));
+    seq_tv_t *inpv = (seq_tv_t *)Malloc(n * sizeof(seq_tv_t) PASS_REGS);
+    seq_tv_t *out = (seq_tv_t *)Malloc(sizeof(seq_tv_t) PASS_REGS);
     int i = 0;
     if (!inpv) {
       LOCAL_Error_TYPE = RESOURCE_ERROR_HEAP;
@@ -1434,8 +1434,8 @@ restart_aux:
       pop_text_stack(l);
       return rc;
     }
-    seq_tv_t *inpv = (seq_tv_t *)Malloc(n * sizeof(seq_tv_t));
-    seq_tv_t *out = (seq_tv_t *)Malloc(sizeof(seq_tv_t));
+    seq_tv_t *inpv = (seq_tv_t *)Malloc(n * sizeof(seq_tv_t) PASS_REGS);
+    seq_tv_t *out = (seq_tv_t *)Malloc(sizeof(seq_tv_t) PASS_REGS);
     if (!inpv) {
       LOCAL_Error_TYPE = RESOURCE_ERROR_HEAP;
       goto error;
@@ -1481,7 +1481,7 @@ restart_aux:
   if (*tailp != TermNil) {
     LOCAL_Error_TYPE = TYPE_ERROR_LIST;
   } else {
-    seq_tv_t *inpv = (seq_tv_t *)Malloc(n * sizeof(seq_tv_t)), out;
+    seq_tv_t *inpv = (seq_tv_t *)Malloc(n * sizeof(seq_tv_t) PASS_REGS), out;
     int i = 0;
     Atom at;
 
@@ -1531,7 +1531,7 @@ restart_aux:
   if (*tailp != TermNil) {
     LOCAL_Error_TYPE = TYPE_ERROR_LIST;
   } else {
-    seq_tv_t *inpv = (seq_tv_t *)Malloc((n * 2 - 1) * sizeof(seq_tv_t)), out;
+    seq_tv_t *inpv = (seq_tv_t *)Malloc((n * 2 - 1) * sizeof(seq_tv_t) PASS_REGS), out;
     int i = 0;
     Atom at;
 
@@ -1761,7 +1761,7 @@ static Int downcase_text_to_atom(USES_REGS1) {
     }
   }
   while (true) {
-    Atom at = Yap_AtomicToLowAtom(t1);
+    Atom at = Yap_AtomicToLowAtom(t1 PASS_REGS);
     if (at == NULL) {
       if (LOCAL_Error_TYPE && Yap_HandleError("downcase_text_to_atom/2"))
         continue;
@@ -1807,7 +1807,7 @@ static Int upcase_text_to_atom(USES_REGS1) {
     }
   }
   while (true) {
-    Atom at = Yap_AtomicToUpAtom(t1);
+    Atom at = Yap_AtomicToUpAtom(t1 PASS_REGS);
     if (at == NULL) {
       if (LOCAL_Error_TYPE && Yap_HandleError("upcase_text_to_atom/2"))
         continue;
@@ -1847,7 +1847,7 @@ static Int downcase_text_to_string(USES_REGS1) {
       return (FALSE);
     }
     while (true) {
-      Term t = Yap_AtomicToLowString(t1);
+      Term t = Yap_AtomicToLowString(t1 PASS_REGS);
       if (t == TermZERO) {
         if (LOCAL_Error_TYPE && Yap_HandleError("downcase_text_to_string/2"))
           continue;
@@ -1884,7 +1884,7 @@ static Int upcase_text_to_string(USES_REGS1) {
   }
   int l = push_text_stack();
   while (true) {
-    Term t = Yap_AtomicToUpString(t1);
+    Term t = Yap_AtomicToUpString(t1 PASS_REGS);
 
     if (t == TermZERO) {
       if (LOCAL_Error_TYPE && Yap_HandleError("upcase_text_to_string/2"))
@@ -1925,7 +1925,7 @@ static Int downcase_text_to_codes(USES_REGS1) {
   }
   int l = push_text_stack();
   while (true) {
-    Term t = Yap_AtomicToLowListOfCodes(t1);
+    Term t = Yap_AtomicToLowListOfCodes(t1 PASS_REGS);
     if (t == TermZERO) {
       if (LOCAL_Error_TYPE && Yap_HandleError("downcase_text_to_codes/2"))
         continue;
@@ -1963,7 +1963,7 @@ static Int upcase_text_to_codes(USES_REGS1) {
   }
   int l = push_text_stack();
   while (true) {
-    Term t = Yap_AtomicToUpListOfCodes(t1);
+    Term t = Yap_AtomicToUpListOfCodes(t1 PASS_REGS);
     if (t == TermZERO) {
       if (LOCAL_Error_TYPE && Yap_HandleError("upcase_text_to_codes/2"))
         continue;
@@ -2001,7 +2001,7 @@ static Int downcase_text_to_chars(USES_REGS1) {
   }
   int l = push_text_stack();
   while (true) {
-    Term t = Yap_AtomicToLowListOfAtoms(t1);
+    Term t = Yap_AtomicToLowListOfAtoms(t1 PASS_REGS);
 
     if (t == TermZERO) {
       if (LOCAL_Error_TYPE && Yap_HandleError("downcase_text_to_to_chars/2"))
@@ -2040,7 +2040,7 @@ static Int upcase_text_to_chars(USES_REGS1) {
   }
   int l = push_text_stack();
   while (true) {
-    Term t = Yap_AtomicToUpListOfAtoms(t1);
+    Term t = Yap_AtomicToUpListOfAtoms(t1 PASS_REGS);
     if (t == TermZERO) {
       if (LOCAL_Error_TYPE && Yap_HandleError("upcase_text_to_chars/2"))
         continue;
@@ -2091,7 +2091,7 @@ static Int atom_split(USES_REGS1) {
     return false;
   }
   size_t b_mid = skip_utf8(s0, u_mid) - s0;
-  s1 = s10 = Malloc(b_mid + 1);
+  s1 = s10 = Malloc(b_mid + 1 PASS_REGS);
   memmove(s1, s, b_mid);
   s1[b_mid] = '\0';
   to1 = MkAtomTerm(Yap_ULookupAtom(s10));

--- a/C/attvar.c
+++ b/C/attvar.c
@@ -165,6 +165,7 @@ static Term AttVarToTerm(CELL *orig) {
 
 static attvar_record *AttsFromTerm(Term inp)
 {
+  CACHE_REGS
   if (IsVarTerm(inp)) {
     if (IsAttachedTerm(inp)) {
       attvar_record *attv;

--- a/C/cdmgr.c
+++ b/C/cdmgr.c
@@ -935,6 +935,7 @@ static void add_first_static(PredEntry *p, yamop *cp, int spy_flag) {
 
 /* p is already locked */
 static void add_first_dynamic(PredEntry *p, yamop *cp, int spy_flag) {
+  CACHE_REGS
   yamop *ncp = ((DynamicClause *)NULL)->ClCode;
   DynamicClause *cl;
 
@@ -2878,6 +2879,7 @@ static Int p_clean_up_dead_clauses(USES_REGS1) {
 }
 
 void Yap_HidePred(PredEntry *pe) {
+  CACHE_REGS
 
   if (pe->PredFlags & HiddenPredFlag)
     return;
@@ -3641,7 +3643,7 @@ static Int fetch_next_static_clause(PredEntry *pe, yamop *i_code, yamop *cp_ptr,
           }
         } else {
           LOCAL_Error_TYPE = YAP_NO_ERROR;
-          if (!Yap_dogc(0, NULL)) {
+          if (!Yap_dogc(0, NULL PASS_REGS)) {
             UNLOCKPE(45, pe);
             Yap_ThrowError(RESOURCE_ERROR_STACK, TermNil, LOCAL_ErrorMessage);
             return false;
@@ -3649,7 +3651,7 @@ static Int fetch_next_static_clause(PredEntry *pe, yamop *i_code, yamop *cp_ptr,
         }
       } else {
         LOCAL_Error_TYPE = YAP_NO_ERROR;
-        if (!Yap_dogc(0, NULL)) {
+        if (!Yap_dogc(0, NULL PASS_REGS)) {
           UNLOCKPE(45, pe);
           Yap_ThrowError(RESOURCE_ERROR_STACK, TermNil, LOCAL_ErrorMessage);
           return FALSE;

--- a/C/eval.c
+++ b/C/eval.c
@@ -217,7 +217,7 @@ static Int p_is(USES_REGS1) { /* X is Y	 */
   }
   do {
     go = false;
-    out = Yap_Eval(t PASS_REGS);
+    out = Yap_Eval(t);
     go = Yap_CheckArithError();
   } while (go);
   return Yap_unify_constant(ARG1, out);

--- a/C/fli_absmi_insts.h
+++ b/C/fli_absmi_insts.h
@@ -371,7 +371,7 @@
       save_machine_regs();
       SREG = (CELL *)YAP_ExecuteFirst(PREG->y_u.OtapFs.p,
                                       (CPredicate)(PREG->y_u.OtapFs.f));
-      Yap_ResetException( worker_id );
+      Yap_ResetException( LOCAL_ActiveError );
       restore_machine_regs();
       setregs();
       LOCAL_PrologMode &= UserMode;
@@ -412,7 +412,7 @@
       save_machine_regs();
       SREG = (CELL *)YAP_ExecuteNext(PREG->y_u.OtapFs.p,
                                      (CPredicate)(PREG->y_u.OtapFs.f));
-      Yap_ResetException( worker_id);
+      Yap_ResetException( LOCAL_ActiveError );
       restore_machine_regs();
       setregs();
       LOCAL_PrologMode &= ~UserCCallMode;

--- a/C/globals.c
+++ b/C/globals.c
@@ -189,6 +189,7 @@ static Term CreateNewArena(CELL *ptr, UInt size) {
 }
 
 static inline void enter_cell_space(cell_space_t *cs, Term *arenap) {
+  CACHE_REGS
   cs->oH = HR;
   cs->oHB = HB;
   cs->oASP = ASP;
@@ -202,6 +203,7 @@ static inline void enter_cell_space(cell_space_t *cs, Term *arenap) {
 }
 
 static inline void exit_cell_space(cell_space_t *cs) {
+  CACHE_REGS
   if (cs->arenaL) {
     HR = cs->oH;
   }
@@ -771,7 +773,7 @@ overflow:
     to_visit--;
      VUNMARK(to_visit->oldp, to_visit->oldv);
   }
-  clean_tr(TR0);
+  clean_tr(TR0 PASS_REGS);
   HB = HB0;
     if (&LOCAL_GlobalArena == arenap)
       LOCAL_GlobalArenaOverflows++;
@@ -789,7 +791,7 @@ overflow:
 	return 0L;
       }
     } else {
-      if (!Yap_expand(0)) {
+      if (!Yap_expand(0 PASS_REGS)) {
   close_stack(&stt);
 
 	Yap_ThrowError(RESOURCE_ERROR_STACK, TermNil, LOCAL_ErrorMessage);
@@ -810,7 +812,7 @@ overflow:
      VUNMARK(to_visit->oldp, to_visit->oldv);
   }
 #endif
-  clean_tr(TR0);
+  clean_tr(TR0 PASS_REGS);
     HR = HB;
     if (arenap) {
      *arenap = CloseArena(cspace   PASS_REGS);
@@ -929,6 +931,7 @@ p_rational_tree_to_forest(USES_REGS1) /* copy term t to a new instance  */
 Term
 Yap_TermAsForest(Term t1, Term *list) /* copy term t to a new instance  */
 {
+  CACHE_REGS
   *list = TermNil;
   Term t = CopyTermToArena(t1, false, false, 2, NULL, list, 0 PASS_REGS);
   if (t == 0L)
@@ -957,7 +960,7 @@ static Term CreateTermInArena(Atom Na, UInt Nar, UInt arity, Term *newarena,
   UInt i;
 
  restart:
-  enter_cell_space(&cells, newarena PASS_REGS);
+  enter_cell_space(&cells, newarena);
   tf = AbsAppl(HR);
   HR[0] = (CELL) f;
   HR += 1 + ArityOfFunctor(f);
@@ -968,7 +971,7 @@ static Term CreateTermInArena(Atom Na, UInt Nar, UInt arity, Term *newarena,
       //      CELL *old_top = ArenaLimit(*nsizeof(CELL)ewarena);
       if (*newarena == LOCAL_GlobalArena)
 	LOCAL_GlobalArenaOverflows++;
-      *newarena = CloseArena(&cells);
+      *newarena = CloseArena(&cells PASS_REGS);
 
       if ((*newarena = GrowArena(*newarena, Nar * sizeof(CELL), arity + 1,
 				 &cells PASS_REGS)) == 0) {
@@ -2028,6 +2031,7 @@ static void DelHeapRoot(CELL *pt, UInt sz) {
 }
 
 static CELL *new_heap_entry(CELL *qd) {
+  CACHE_REGS
   size_t hsize, hmsize;
   if (!qd)
     return FALSE;
@@ -2389,6 +2393,7 @@ static Term DelBeamMin(CELL *pt, CELL *pt2, UInt sz) {
 }
 
 static size_t new_beam_entry(CELL *qd) {
+  CACHE_REGS
   size_t hsize, hmsize;
   hsize = IntegerOfTerm(qd[HEAP_SIZE]);
   hmsize = IntegerOfTerm(qd[HEAP_MAX]);

--- a/C/gmp_support.c
+++ b/C/gmp_support.c
@@ -29,6 +29,7 @@
 static inline Term
 MkBigAndClose(MP_INT *new)
 {
+  CACHE_REGS
   Term t = Yap_MkBigIntTerm(new);
   mpz_clear(new);
   if (t == TermNil) {
@@ -40,6 +41,7 @@ MkBigAndClose(MP_INT *new)
 static inline Term
 MkRatAndClose(MP_RAT *new)
 {
+  CACHE_REGS
   Term t = Yap_MkBigRatTerm(new);
   mpq_clear(new);
   if (t == TermNil) {
@@ -214,6 +216,7 @@ Yap_gmp_sub_big_int(Term t, Int i)
 Term 
 Yap_gmp_div_int_big(Int i, Term t)
 {
+  CACHE_REGS
   CELL *pt = RepAppl(t);
   if (pt[1] == BIG_INT) {
     /* cool */
@@ -233,6 +236,7 @@ Yap_gmp_div_int_big(Int i, Term t)
 Term 
 Yap_gmp_div_big_int(Term t, Int i)
 {
+  CACHE_REGS
   CELL *pt = RepAppl(t);
   if (pt[1] == BIG_INT) {
     MP_INT new;
@@ -276,6 +280,7 @@ Yap_gmp_div_big_int(Term t, Int i)
 Term 
 Yap_gmp_div2_big_int(Term t, Int i)
 {
+  CACHE_REGS
   CELL *pt = RepAppl(t);
   if (pt[1] == BIG_INT) {
     MP_INT new;
@@ -307,6 +312,7 @@ Yap_gmp_div2_big_int(Term t, Int i)
 Term 
 Yap_gmp_and_int_big(Int i, Term t)
 {
+  CACHE_REGS
   MP_INT new;
   CELL *pt = RepAppl(t);
   MP_INT *b;
@@ -324,6 +330,7 @@ Yap_gmp_and_int_big(Int i, Term t)
 Term 
 Yap_gmp_ior_int_big(Int i, Term t)
 {
+  CACHE_REGS
   MP_INT new;
   CELL *pt = RepAppl(t);
   MP_INT *b;
@@ -363,6 +370,7 @@ mpz_xor(MP_INT *new, MP_INT *r1, MP_INT *r2)
 Term 
 Yap_gmp_xor_int_big(Int i, Term t)
 {
+  CACHE_REGS
   MP_INT new;
   CELL *pt = RepAppl(t);
   MP_INT *b;
@@ -616,6 +624,7 @@ Yap_gmp_div2_big_big(Term t1, Term t2)
 Term 
 Yap_gmp_and_big_big(Term t1, Term t2)
 {
+  CACHE_REGS
   CELL *pt1 = RepAppl(t1);
   CELL *pt2 = RepAppl(t2);
   if (pt1[1] == BIG_INT && pt2[1] == BIG_INT) {
@@ -637,6 +646,7 @@ Yap_gmp_and_big_big(Term t1, Term t2)
 Term 
 Yap_gmp_ior_big_big(Term t1, Term t2)
 {
+  CACHE_REGS
   CELL *pt1 = RepAppl(t1);
   CELL *pt2 = RepAppl(t2);
   if (pt1[1] == BIG_INT && pt2[1] == BIG_INT) {
@@ -658,6 +668,7 @@ Yap_gmp_ior_big_big(Term t1, Term t2)
 Term 
 Yap_gmp_xor_big_big(Term t1, Term t2)
 {
+  CACHE_REGS
   CELL *pt1 = RepAppl(t1);
   CELL *pt2 = RepAppl(t2);
   if (pt1[1] == BIG_INT && pt2[1] == BIG_INT) {
@@ -679,6 +690,7 @@ Yap_gmp_xor_big_big(Term t1, Term t2)
 Term 
 Yap_gmp_mod_big_big(Term t1, Term t2)
 {
+  CACHE_REGS
   CELL *pt1 = RepAppl(t1);
   CELL *pt2 = RepAppl(t2);
   if (pt1[1] == BIG_INT && pt2[1] == BIG_INT) {
@@ -700,6 +712,7 @@ Yap_gmp_mod_big_big(Term t1, Term t2)
 Term 
 Yap_gmp_mod_big_int(Term t, Int i2)
 {
+  CACHE_REGS
   CELL *pt = RepAppl(t);
   if (pt[1] != BIG_INT) {
     Yap_ArithError(TYPE_ERROR_INTEGER, t, "mod/2");
@@ -756,6 +769,7 @@ Yap_gmp_mod_int_big(Int i1, Term t)
 Term 
 Yap_gmp_rem_big_big(Term t1, Term t2)
 {
+  CACHE_REGS
   CELL *pt1 = RepAppl(t1);
   CELL *pt2 = RepAppl(t2);
   if (pt1[1] == BIG_INT && pt2[1] == BIG_INT) {
@@ -777,6 +791,7 @@ Yap_gmp_rem_big_big(Term t1, Term t2)
 Term 
 Yap_gmp_rem_big_int(Term t, Int i2)
 {
+  CACHE_REGS
   CELL *pt = RepAppl(t);
   if (pt[1] != BIG_INT) {
     Yap_ArithError(TYPE_ERROR_INTEGER, t, "rem/2");
@@ -806,6 +821,7 @@ Yap_gmp_rem_int_big(Int i1, Term t)
 Term 
 Yap_gmp_gcd_big_big(Term t1, Term t2)
 {
+  CACHE_REGS
   CELL *pt1 = RepAppl(t1);
   CELL *pt2 = RepAppl(t2);
   if (pt1[1] == BIG_INT && pt2[1] == BIG_INT) {
@@ -1468,6 +1484,7 @@ Yap_gmp_abs_big(Term t)
 Term
 Yap_gmp_unot_big(Term t)
 {
+  CACHE_REGS
   CELL *pt = RepAppl(t);
   if (pt[1] == BIG_INT) {
     MP_INT *b = Yap_BigIntOfTerm(t);
@@ -1569,6 +1586,7 @@ Yap_gmp_trunc(Term t)
 Term
 Yap_gmp_float_fractional_part(Term t)
 {
+  CACHE_REGS
   CELL *pt = RepAppl(t);
   if (pt[1] == BIG_INT) {
     Yap_ArithError(TYPE_ERROR_FLOAT, t, "X is float_fractional_part(%f)", FloatOfTerm(t));
@@ -1589,6 +1607,7 @@ Yap_gmp_float_fractional_part(Term t)
 Term
 Yap_gmp_float_integer_part(Term t)
 {
+  CACHE_REGS
   CELL *pt = RepAppl(t);
   if (pt[1] == BIG_INT) {
     Yap_ArithError(TYPE_ERROR_FLOAT, t, "X is float_integer_part(%f)", FloatOfTerm(t));

--- a/C/grow.c
+++ b/C/grow.c
@@ -787,6 +787,7 @@ static_growheap(size_t esize, bool fix_code, struct intermediates *cip USES_REGS
 }
 
 static size_t expand_stacks( size_t *minimal_requestp, size_t request) {
+    CACHE_REGS
     if (request < YAP_ALLOC_SIZE)
         request = YAP_ALLOC_SIZE;
     request = AdjustPageSize(request);
@@ -812,6 +813,7 @@ static size_t expand_stacks( size_t *minimal_requestp, size_t request) {
 
 static void
 adjust_stack_ptrs(size_t request, size_t minimal_request, ADDR old_GlobalBase ) {
+    CACHE_REGS
 /* we got over a hole */
     if (minimal_request) {
 /* we require a realloc */
@@ -826,6 +828,7 @@ adjust_stack_ptrs(size_t request, size_t minimal_request, ADDR old_GlobalBase ) 
 }
 
 static void stack_msg_in(CELL *hsplit, size_t request) {
+    CACHE_REGS
     char *vb_msg2 = "";
     vb_msg2 = "NB variable overflow ";
 #if  defined(YAPOR_THREADS)

--- a/C/heapgc.c
+++ b/C/heapgc.c
@@ -1576,6 +1576,7 @@ static inline void output_env_entry(CELL *gc_ENV, yamop *e_CP, UInt size) {
 static void
 mark_env_cells(CELL *gc_ENV, UInt size, CELL *pvbmap)
 {
+  CACHE_REGS
   CELL_PTR saved_var;
   UInt bmap, bit = 1;
   if (size <= EnvSizeInCells || pvbmap == NULL) {
@@ -2870,6 +2871,7 @@ static void sweep_trail(choiceptr gc_B, tr_fr_ptr old_TR USES_REGS) {
 static void
 sweep_env_cells(CELL *gc_ENV, UInt size, CELL *pvbmap)
 {
+  CACHE_REGS
   CELL_PTR saved_var;
   UInt bmap, bit = 1;
   if (size <= EnvSizeInCells || pvbmap == NULL) {

--- a/C/index.c
+++ b/C/index.c
@@ -976,12 +976,12 @@ static void copy_back(ClauseDef *dest, CELL *pt, int max) {
 
 /* sort a group of clauses by using their tags */
 static void sort_group(GroupDef *grp, CELL *top, struct intermediates *cint) {
+  CACHE_REGS
   int max = (grp->LastClause - grp->FirstClause) + 1, i;
   CELL *pt, *base;
     int lvl = push_text_stack();
 #if USE_SYSTEM_MALLOC
-  if (!(base = Malloc(2 * max * sizeof(CELL)))) {
-    CACHE_REGS
+  if (!(base = Malloc(2 * max * sizeof(CELL) PASS_REGS))) {
     save_machine_regs();
     LOCAL_Error_Size = 2 * max * sizeof(CELL);
     siglongjmp(cint->CompilerBotch, 2);

--- a/C/load_foreign.c
+++ b/C/load_foreign.c
@@ -245,7 +245,7 @@ static Int p_open_shared_objects(USES_REGS1) {
 
 static Int check_embedded(USES_REGS1)
 {
-  const char *s = Yap_TextTermToText(Deref(ARG1));
+  const char *s = Yap_TextTermToText(Deref(ARG1) PASS_REGS);
   if (!s)
     return false;
 #if EMBEDDED_MYDDAS

--- a/C/parser.c
+++ b/C/parser.c
@@ -162,7 +162,7 @@ VarEntry *Yap_LookupVar(const char *var) /* lookup variable in variables table
         p = p->VarRight;
       }
     }
-    p = Malloc(sizeof(VarEntry));
+    p = Malloc(sizeof(VarEntry) PASS_REGS);
     *op = p;
     p->VarLeft = p->VarRight = NULL;
     p->hv = hv;
@@ -170,7 +170,7 @@ VarEntry *Yap_LookupVar(const char *var) /* lookup variable in variables table
     p->VarRep = vat;
    } else {
     /* anon var */
-    p = Malloc(sizeof(VarEntry));
+    p = Malloc(sizeof(VarEntry) PASS_REGS);
     p->VarLeft = LOCAL_AnonVarTable;
     LOCAL_AnonVarTable = p;
     p->VarRight = NULL;
@@ -485,7 +485,7 @@ static Term ParseArgs(Atom a, Term close, JMPBUFF *FailBuff, Term arg1,
     if (LOCAL_ParserAuxSp + 1 >= LOCAL_ParserAuxMax) {
         size_t sz = LOCAL_ParserAuxMax-LOCAL_ParserAuxBase, off = LOCAL_ParserAuxSp-LOCAL_ParserAuxBase;
         sz += 4096;
-        if ((LOCAL_ParserAuxBase = Realloc(LOCAL_ParserAuxBase, sz) )== NULL) {
+        if ((LOCAL_ParserAuxBase = Realloc(LOCAL_ParserAuxBase, sz PASS_REGS) )== NULL) {
             syntax_msg("line %d: Parser Stack Overflow", LOCAL_tokptr->TokLine);
             FAIL;
         }
@@ -959,7 +959,7 @@ Term Yap_Parse(UInt prio, encoding_t enc, Term cmod) {
   if (!sigsetjmp(FailBuff.JmpBuff, 0)) {
     LOCAL_ActiveError->errorMsg=NULL;
     LOCAL_ActiveError->errorMsgLen=0;
-                                                  LOCAL_ParserAuxSp = LOCAL_ParserAuxBase = Malloc(4096*sizeof(CELL));
+                                                  LOCAL_ParserAuxSp = LOCAL_ParserAuxBase = Malloc(4096*sizeof(CELL) PASS_REGS);
                                                   LOCAL_ParserAuxMax =   LOCAL_ParserAuxBase+4096;
     t = ParseTerm(prio, &FailBuff, enc, cmod PASS_REGS);
 #if DEBUG

--- a/C/signals.c
+++ b/C/signals.c
@@ -138,7 +138,7 @@ static yap_signals ProcessSIGINT(void) {
 
 inline static void do_signal(int wid, yap_signals sig USES_REGS) {
 #if THREADS
-  __sync_fetch_and_or(&REMOTE(wid)->Signals_, SIGNAL_TO_BIT(sig));
+  __sync_fetch_and_or(&REMOTE(wid)->Signals, SIGNAL_TO_BIT(sig));
   if (!REMOTE_InterruptsDisabled(wid)) {
     REMOTE_ThreadHandle(wid).current_yaam_regs->CreepFlag_ =
         Unsigned(REMOTE_ThreadHandle(wid).current_yaam_regs->LCL0_);
@@ -189,12 +189,14 @@ inline static bool get_signal(yap_signals sig USES_REGS) {
 }
 
 bool Yap_DisableInterrupts(int wid) {
+  CACHE_REGS
   LOCAL_InterruptsDisabled = true;
   YAPEnterCriticalSection();
   return true;
 }
 
 bool Yap_EnableInterrupts(int wid) {
+  CACHE_REGS
   LOCAL_InterruptsDisabled = false;
   YAPLeaveCriticalSection();
   return true;

--- a/C/stack.c
+++ b/C/stack.c
@@ -1160,7 +1160,8 @@ static Term error_culprit(bool internal USES_REGS) {
 }
 
 yap_error_descriptor_t *
-Yap_prolog_add_culprit(yap_error_descriptor_t *t PASS_REGS) {
+Yap_prolog_add_culprit(yap_error_descriptor_t *t) {
+    CACHE_REGS
     PredEntry *pe;
     void *startp, *endp;
     // case number 1: Yap_Error called from built-in.
@@ -1486,6 +1487,7 @@ static Int p_cpc_info(USES_REGS1) {
 }
 
 static PredEntry *choicepoint_owner(choiceptr cptr, Term *tp, yamop **nclp) {
+    CACHE_REGS
     PredEntry *pe =
             NULL;
     int go_on = TRUE;
@@ -1782,7 +1784,7 @@ typedef struct buf_struct_t {
     lbufsz -= sz;                    \
     break;                        \
       }                            \
-      char *nbuf = Realloc(buf, bufsize += 1024);    \
+      char *nbuf = Realloc(buf, bufsize += 1024 PASS_REGS);    \
       lbuf = nbuf + (lbuf-buf);                \
       buf  = nbuf;                    \
       lbufsz += 1024;                    \
@@ -1791,6 +1793,7 @@ typedef struct buf_struct_t {
 
 
 static char *ADDSTR(const char *STR, struct buf_struct_t *bufp) {
+    CACHE_REGS  \
     \
     while (true) {
         \
@@ -1804,7 +1807,7 @@ static char *ADDSTR(const char *STR, struct buf_struct_t *bufp) {
 
         } \
 
-        char *nbuf = Realloc(buf, bufsize += 1024);    \
+        char *nbuf = Realloc(buf, bufsize += 1024 PASS_REGS);    \
       lbuf = nbuf + (lbuf - buf);                \
       buf = nbuf;                    \
       lbufsz += 1024;                    \
@@ -1860,7 +1863,7 @@ const char *Yap_dump_stack(void) {
     CACHE_REGS
     int lvl = push_text_stack();
     struct buf_struct_t b, *bufp = &b;
-    buf = Malloc(4096);
+    buf = Malloc(4096 PASS_REGS);
     lbuf = buf;
     bufsize = 4096;
     lbufsz = bufsize - 256;
@@ -1993,6 +1996,7 @@ const char *Yap_dump_stack(void) {
 
 
 static bool outputep(CELL *ep, struct buf_struct_t *bufp) {
+    CACHE_REGS
     PredEntry *pe = EnvPreg((yamop *) ep);
     if (!ONLOCAL(ep) || (Unsigned(ep) & (sizeof(CELL) - 1)))
         return false;
@@ -2023,6 +2027,7 @@ static bool outputep(CELL *ep, struct buf_struct_t *bufp) {
 }
 
 static bool outputcp(choiceptr cp, struct buf_struct_t *bufp) {
+    CACHE_REGS
     choiceptr b_ptr = cp;
     PredEntry *pe = Yap_PredForChoicePt(b_ptr, NULL);
     ADDBUF(snprintf(lbuf, lbufsz, "%% %p ", cp));
@@ -2113,7 +2118,7 @@ char *DumpActiveGoals(USES_REGS1) {
     int lvl = push_text_stack();
     struct buf_struct_t buf0, *bufp = &buf0;
 
-    buf = Malloc(4096);
+    buf = Malloc(4096 PASS_REGS);
     lbuf = buf;
     bufsize = 4096;
     lbufsz = bufsize - 256;
@@ -2158,12 +2163,13 @@ char *DumpActiveGoals(USES_REGS1) {
  *
  */
 char *Yap_output_bug_location(yamop *yap_pc, int where_from, int psize) {
+    CACHE_REGS
     Atom pred_name;
     UInt pred_arity;
     Term pred_module;
     Int cl;
 
-    char *o = Malloc(256);
+    char *o = Malloc(256 PASS_REGS);
     if ((cl = Yap_PredForCode(yap_pc, where_from, &pred_name, &pred_arity,
                               &pred_module)) == 0) {
         /* system predicate */
@@ -2336,6 +2342,7 @@ static Int ancestor_location(USES_REGS1) {
 static int Yap_DebugDepthMax = 4;
 
 void ShowTerm(Term *tp, int depth) {
+    CACHE_REGS
     if (depth == Yap_DebugDepthMax) return;
     Term t = *tp;
     if (IsVarTerm(t)) {
@@ -2377,6 +2384,7 @@ void ShowTerm(Term *tp, int depth) {
 
 
 void Yap_ShowTerm(Term t) {
+    CACHE_REGS
     *HR++ = t;
     ShowTerm(HR - 1, 0);
 }
@@ -2385,6 +2393,7 @@ void Yap_ShowTerm(Term t) {
  extern void pp(Term, int);
 
 void pp(Term t, int lvl) {
+  CACHE_REGS
   int i;
   if (lvl>6)
     return;

--- a/C/stdpreds.c
+++ b/C/stdpreds.c
@@ -1354,7 +1354,7 @@ static Int p_executable(USES_REGS1) {
 
     Yap_AbsoluteFile(GLOBAL_argv[0], true);
     if (!tmp || tmp[0] == '\0' ) {
-      tmp = Malloc(YAP_FILENAME_MAX + 1);
+      tmp = Malloc(YAP_FILENAME_MAX + 1 PASS_REGS);
       strncpy((char *)tmp, Yap_FindExecutable(), YAP_FILENAME_MAX);
     }
   Atom at = Yap_LookupAtom(tmp);

--- a/C/terms.c
+++ b/C/terms.c
@@ -135,7 +135,7 @@ bool Yap_IsCyclicTerm(Term t USES_REGS) {
 */
 static Int cyclic_term(USES_REGS1) /* cyclic_term(+T)		 */
 {
-  return Yap_IsCyclicTerm(Deref(ARG1));
+  return Yap_IsCyclicTerm(Deref(ARG1) PASS_REGS);
 }
 
 /**
@@ -675,7 +675,7 @@ static Int free_variables_in_term(USES_REGS1) {
     out = TermNil;
   else {
     out = new_vars_in_complex_term(&(t)-1, &(t),
-                                   Yap_TermVariables(bounds, 3) PASS_REGS);
+                                   Yap_TermVariables(bounds, 3 PASS_REGS) PASS_REGS);
   }
 
   if (found_module && t != t0) {
@@ -818,7 +818,7 @@ static Term numbervars_in_complex_term(CELL *pt0_, CELL *pt0_end_, Int vno,
 }
 
 Int Yap_NumberVars(Term t, Int numbv, bool handle_singles,
-                   Int *tr_entries) /*
+                   Int *tr_entries USES_REGS) /*
                                      * numbervariables in term t         */
 {
     if ( handle_singles ) return t;
@@ -845,7 +845,7 @@ static Int p_numbervars(USES_REGS1) {
         Yap_Error(TYPE_ERROR_INTEGER, t2, "numbervars/3");
         return (false);
     }
-    out = Yap_NumberVars(Deref(ARG1), IntegerOfTerm(t2), false, NULL);
+    out = Yap_NumberVars(Deref(ARG1), IntegerOfTerm(t2), false, NULL PASS_REGS);
     return Yap_unify(ARG3, MkIntegerTerm(out));
 }
 
@@ -887,7 +887,7 @@ static int max_numbered_var(CELL *pt0_, CELL *pt0_end_, Int *maxp USES_REGS) {
   return 0;
 }
 
-static Int MaxNumberedVar(Term inp, arity_t arity PASS_REGS) {
+static Int MaxNumberedVar(Term inp, arity_t arity USES_REGS) {
   Term t = Deref(inp);
 
   if (IsPrimitiveTerm(t)) {
@@ -919,6 +919,7 @@ static Int largest_numbervar(USES_REGS1) {
 
 
 void Yap_InitTermCPreds(void) {
+  CACHE_REGS
   Yap_InitCPred("term_variables", 2, term_variables, 0);
   Yap_InitCPred("term_variables", 3, term_variables3, 0);
   Yap_InitCPred("$variables_in_term", 3, variables_in_term, 0);

--- a/C/text.c
+++ b/C/text.c
@@ -74,7 +74,7 @@ static void *codes2buf(Term t0, void *b0, bool get_codes,
   size_t length = 0;
 
   if (t == TermNil) {
-    st0 = Malloc(4);
+    st0 = Malloc(4 PASS_REGS);
     st0[0] = 0;
     return st0;
   }
@@ -161,7 +161,7 @@ static void *codes2buf(Term t0, void *b0, bool get_codes,
     }
   }
 
-  st0 = st = Malloc(length + 1);
+  st0 = st = Malloc(length + 1 PASS_REGS);
   t = t0;
   if (codes) {
     while (IsPairTerm(t)) {
@@ -190,11 +190,12 @@ st +=2;
 }
 
 static unsigned char *latin2utf8(seq_tv_t *inp) {
+  CACHE_REGS
   unsigned char *b0 = inp->val.uc;
   size_t sz = strlen(inp->val.c);
   sz *= 2;
   int ch;
-  unsigned char *buf = Malloc(sz + 1), *pt = buf;
+  unsigned char *buf = Malloc(sz + 1 PASS_REGS), *pt = buf;
   if (!buf)
     return NULL;
   while ((ch = *b0++)) {
@@ -209,9 +210,10 @@ static unsigned char *latin2utf8(seq_tv_t *inp) {
 }
 
 static unsigned char *wchar2utf8(seq_tv_t *inp) {
+  CACHE_REGS
   size_t sz = wcslen(inp->val.w) * 4;
   wchar_t *b0 = inp->val.w;
-  unsigned char *buf = Malloc(sz + 1), *pt = buf;
+  unsigned char *buf = Malloc(sz + 1 PASS_REGS), *pt = buf;
   int ch;
   if (!buf)
     return NULL;
@@ -300,7 +302,7 @@ unsigned char *Yap_readText(seq_tv_t *inp USES_REGS) {
   }
   if ((inp->val.t == TermNil) && inp->type & YAP_STRING_PREFER_LIST )
   {
-    out = Malloc(4);
+    out = Malloc(4 PASS_REGS);
       memset(out, 0, 4);
       POPRET( out );
     }
@@ -309,7 +311,7 @@ unsigned char *Yap_readText(seq_tv_t *inp USES_REGS) {
     // Yap_DebugPlWriteln(inp->val.t);
     Atom at = AtomOfTerm(inp->val.t);
     if (RepAtom(at)->UStrOfAE[0] == 0) {
-      out = Malloc(4);
+      out = Malloc(4 PASS_REGS);
       memset(out, 0, 4);
       POPRET( out );
     }
@@ -319,7 +321,7 @@ unsigned char *Yap_readText(seq_tv_t *inp USES_REGS) {
     }
     {
       size_t sz = strlen(at->StrOfAE);
-      out = Malloc(sz + 1);
+      out = Malloc(sz + 1 PASS_REGS);
       strcpy(out, at->StrOfAE);
       POPRET( out );
     }
@@ -329,7 +331,7 @@ unsigned char *Yap_readText(seq_tv_t *inp USES_REGS) {
     // Yap_DebugPlWriteln(inp->val.t);
     const char *s = StringOfTerm(inp->val.t);
     if (s[0] == 0) {
-      out = Malloc(4);
+      out = Malloc(4 PASS_REGS);
       memset(out, 0, 4);
       POPRET( out );
     }
@@ -340,7 +342,7 @@ unsigned char *Yap_readText(seq_tv_t *inp USES_REGS) {
     {
       inp->type |= YAP_STRING_IN_TMP;
       size_t sz = strlen(s);
-      out = Malloc(sz + 1);
+      out = Malloc(sz + 1 PASS_REGS);
       strcpy(out, s);
       POPRET( out );
     }
@@ -368,7 +370,7 @@ unsigned char *Yap_readText(seq_tv_t *inp USES_REGS) {
   if (inp->type & YAP_STRING_INT && IsIntegerTerm(inp->val.t)) {
     // ASCII, so both LATIN1 and UTF-8
     // Yap_DebugPlWriteln(inp->val.t);
-    out = Malloc(2 * MaxTmp(PASS_REGS1));
+    out = Malloc(2 * MaxTmp(PASS_REGS1) PASS_REGS);
     if (snprintf(out, MaxTmp(PASS_REGS1) - 1, Int_FORMAT,
                  IntegerOfTerm(inp->val.t)) < 0) {
       AUX_ERROR(inp->val.t, 2 * MaxTmp(PASS_REGS1), out, char);
@@ -376,7 +378,7 @@ unsigned char *Yap_readText(seq_tv_t *inp USES_REGS) {
     POPRET( out );
   }
   if (inp->type & YAP_STRING_FLOAT && IsFloatTerm(inp->val.t)) {
-    out = Malloc(2 * MaxTmp(PASS_REGS1));
+    out = Malloc(2 * MaxTmp(PASS_REGS1) PASS_REGS);
     if (!Yap_FormatFloat(FloatOfTerm(inp->val.t), &out, 1024)) {
       pop_text_stack(lvl);
       return NULL;
@@ -386,7 +388,7 @@ unsigned char *Yap_readText(seq_tv_t *inp USES_REGS) {
 #if USE_GMP
   if (inp->type & YAP_STRING_BIG && IsBigIntTerm(inp->val.t)) {
     // Yap_DebugPlWriteln(inp->val.t);
-    out = Malloc(MaxTmp());
+    out = Malloc(MaxTmp() PASS_REGS);
     if (!Yap_mpz_to_string(Yap_BigIntOfTerm(inp->val.t), out, MaxTmp() - 1,
                            10)) {
       AUX_ERROR(inp->val.t, MaxTmp(PASS_REGS1), out, char);
@@ -557,7 +559,7 @@ static Atom write_atom(void *s0, seq_tv_t *out USES_REGS) {
     return Yap_LookupAtom(s0);
   } else {
     size_t n = get_utf8(s, -1, &ch);
-    unsigned char *buf = Malloc(n + 1);
+    unsigned char *buf = Malloc(n + 1 PASS_REGS);
     memmove(buf, s0, n + 1);
     return Yap_ULookupAtom(buf);
   }
@@ -569,10 +571,10 @@ void *write_buffer(unsigned char *s0, seq_tv_t *out USES_REGS) {
   size_t min = 0, max = leng;
   if (out->enc == ENC_ISO_UTF8) {
     if (out->val.uc == NULL) { // this should always be the case
-      out->val.uc = Malloc(leng + 1);
+      out->val.uc = Malloc(leng + 1 PASS_REGS);
       strcpy(out->val.c, (char *)s0);
     } else if (out->val.uc != s0) {
-      out->val.c = Malloc(leng + 1);
+      out->val.c = Malloc(leng + 1 PASS_REGS);
       strcpy(out->val.c, (char *)s0);
     }
   } else if (out->enc == ENC_ISO_LATIN1) {
@@ -788,7 +790,7 @@ bool Yap_CVT_Text(seq_tv_t *inp, seq_tv_t *out USES_REGS) {
       if (out->max < leng) {
         const unsigned char *ptr = skip_utf8(buf, out->max);
         size_t diff = (ptr - buf);
-        char *nbuf = Malloc(diff + 1);
+        char *nbuf = Malloc(diff + 1 PASS_REGS);
         memmove(nbuf, buf, diff);
         nbuf[diff] = '\0';
         leng = diff;
@@ -798,13 +800,13 @@ bool Yap_CVT_Text(seq_tv_t *inp, seq_tv_t *out USES_REGS) {
     }
     if (out->type & (YAP_STRING_UPCASE | YAP_STRING_DOWNCASE)) {
       if (out->type & YAP_STRING_UPCASE) {
-        if (!upcase(buf, out)) {
+        if (!upcase(buf, out PASS_REGS)) {
           pop_text_stack(l);
           return false;
         }
       }
       if (out->type & YAP_STRING_DOWNCASE) {
-        if (!downcase(buf, out)) {
+        if (!downcase(buf, out PASS_REGS)) {
           pop_text_stack(l);
           return false;
         }
@@ -839,7 +841,7 @@ static unsigned char *concat(int n, void *sv[] USES_REGS) {
     if (s[0])
       room += strlen(s);
   }
-  buf = Malloc(room + 1);
+  buf = Malloc(room + 1 PASS_REGS);
   buf0 = buf;
   for (i = 0; i < n; i++) {
     char *s = sv[i];
@@ -877,7 +879,7 @@ bool Yap_Concat_Text(int tot, seq_tv_t inp[], seq_tv_t *out USES_REGS) {
   int i, j;
 
   int lvl = push_text_stack();
-  bufv = Malloc(tot * sizeof(unsigned char *));
+  bufv = Malloc(tot * sizeof(unsigned char *) PASS_REGS);
   if (!bufv) {
      pop_text_stack(lvl);
     return NULL;
@@ -895,7 +897,7 @@ bool Yap_Concat_Text(int tot, seq_tv_t inp[], seq_tv_t *out USES_REGS) {
     bufv[j++] = nbuf;
   }
   if (j == 0) {
-    buf = Malloc(8);
+    buf = Malloc(8 PASS_REGS);
     memset(buf, 0, 4);
   } else if (j == 1) {
     buf = bufv[0];
@@ -1016,7 +1018,7 @@ const char *Yap_PredIndicatorToUTF8String(PredEntry *ap) {
   smax = s + 1024;
   Term tmod = ap->ModuleOfPred;
   if (tmod) {
-    char *sn = Yap_AtomToUTF8Text(AtomOfTerm(tmod));
+    char *sn = Yap_AtomToUTF8Text(AtomOfTerm(tmod) PASS_REGS);
     stpcpy(s, sn);
     if (smax - s > 1) {
       strcat(s, ":");
@@ -1039,7 +1041,7 @@ const char *Yap_PredIndicatorToUTF8String(PredEntry *ap) {
       return LOCAL_FileNameBuf;
     } else if (ap->PredFlags & AtomDBPredFlag) {
       at = (Atom)(ap->FunctorOfPred);
-      if (!stpcpy(s, Yap_AtomToUTF8Text(at)))
+      if (!stpcpy(s, Yap_AtomToUTF8Text(at PASS_REGS)))
         return NULL;
     } else {
       f = ap->FunctorOfPred;
@@ -1054,7 +1056,7 @@ const char *Yap_PredIndicatorToUTF8String(PredEntry *ap) {
       at = (Atom)(ap->FunctorOfPred);
     }
   }
-  if (!stpcpy(s, Yap_AtomToUTF8Text(at))) {
+  if (!stpcpy(s, Yap_AtomToUTF8Text(at PASS_REGS))) {
     return NULL;
   }
   s += strlen(s);

--- a/C/tracer.c
+++ b/C/tracer.c
@@ -31,6 +31,7 @@
 static char *send_tracer_message(char *start, char *name, arity_t arity,
                                  char *mname, CELL *args, char **s0, char *s,
                                  char **top) {
+  CACHE_REGS
   bool expand = false;
   size_t max = *top - (s + 1);
   int d, min = 1024;
@@ -40,7 +41,7 @@ static char *send_tracer_message(char *start, char *name, arity_t arity,
       Int cbeg = s1 - *s0;
       max = *top - *s0;
       max += min;
-      *s0 = Realloc(*s0, max);
+      *s0 = Realloc(*s0, max PASS_REGS);
 
       *top = *s0 + max;
       max--;
@@ -94,7 +95,7 @@ static char *send_tracer_message(char *start, char *name, arity_t arity,
 //	LOCAL_max_depth=md, LOCAL_max_list=ml, LOCAL_max_write_args = ma;
         size_t sz;
         if (sn == NULL) {
-	  sn = Malloc(strlen("<* error *>")+1);
+	  sn = Malloc(strlen("<* error *>")+1 PASS_REGS);
 	  strcpy((char*)sn, "<* error *>");
         }
         sz = strlen(sn);
@@ -213,7 +214,7 @@ bool low_level_trace__(yap_low_level_port port, PredEntry *pred, CELL *args) {
       jmp_deb(1);
   // if (HR < ASP ) return;
   // fif (vsc_count == 12534) jmp_deb( 2 );
-  char *buf = Malloc(512), *top = buf + 511, *b = buf;
+  char *buf = Malloc(512 PASS_REGS), *top = buf + 511, *b = buf;
       // if (!worker_id) return;
   LOCK(Yap_low_level_trace_lock);
   sc = Yap_heap_regs;

--- a/C/utilpreds.c
+++ b/C/utilpreds.c
@@ -102,7 +102,7 @@ int Yap_copy_complex_term(register CELL *pt0, register CELL *pt0_end,
   int lvl = push_text_stack();
 
   struct cp_frame *tovisit0,
-    *tovisit = Malloc(1024*sizeof(struct cp_frame));
+    *tovisit = Malloc(1024*sizeof(struct cp_frame) PASS_REGS);
   struct cp_frame *tovisit_max;
 
   CELL *HB0 = HB;

--- a/C/write.c
+++ b/C/write.c
@@ -723,6 +723,7 @@ static void write_var(CELL *t, int depth, struct write_globs *wglb) {
 
 static void write_list(Term t, int direction, int depth,
                        struct write_globs *wglb) {
+  CACHE_REGS
   Term ti;
 
   while (1) {

--- a/C/yap-args.c
+++ b/C/yap-args.c
@@ -217,7 +217,7 @@ static bool load_file(const char *b_file USES_REGS) {
 		FunctorOfTerm(t) == functor_command1)) {
       t = ArgOfTerm(1, t);
       if (IsApplTerm(t) && FunctorOfTerm(t) == functor_compile2) {
-	load_file(RepAtom(AtomOfTerm(ArgOfTerm(1, t)))->StrOfAE);
+	load_file(RepAtom(AtomOfTerm(ArgOfTerm(1, t)))->StrOfAE PASS_REGS);
 	Yap_ResetException(LOCAL_ActiveError);
 	continue;
       } else {
@@ -578,8 +578,6 @@ static int dump_runtime_variables(void) {
 X_API YAP_file_type_t Yap_InitDefaults(void *x, char *saved_state, int argc,
 				       char *argv[]) {
 
-  if (!LOCAL_TextBuffer)
-    LOCAL_TextBuffer = Yap_InitTextAllocator();
   YAP_init_args *iap = x;
   memset(iap, 0, sizeof(YAP_init_args));
   iap->Argc = argc;
@@ -1108,6 +1106,7 @@ static void init_hw(YAP_init_args *yap_init, struct ssz_t *spt) {
 }
 
 static void end_init(YAP_init_args *iap) {
+  CACHE_REGS
   YAP_initialized = true;
   if (iap->HaltAfterBoot)
     Yap_exit(0);
@@ -1117,6 +1116,7 @@ static void end_init(YAP_init_args *iap) {
 }
 
 static void start_modules(void) {
+  CACHE_REGS
   Term cm = CurrentModule;
   size_t i;
   for (i = 0; i < n_mdelays; i++) {
@@ -1139,8 +1139,6 @@ X_API void YAP_Init(YAP_init_args *yap_init) {
   if (YAP_initialized)
     /* ignore repeated calls to YAP_Init */
     return;
-  if (!LOCAL_TextBuffer)
-    LOCAL_TextBuffer = Yap_InitTextAllocator();
 
   Yap_Embedded = yap_init->Embedded;
 
@@ -1152,7 +1150,7 @@ X_API void YAP_Init(YAP_init_args *yap_init) {
   //
 
   CACHE_REGS
-    CurrentModule = PROLOG_MODULE;
+  CurrentModule = PROLOG_MODULE;
 
   if (yap_init->QuietMode) {
     setVerbosity(TermSilent);

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -492,6 +492,8 @@ set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS "_YAP_NOT_INSTALLED_=
 #  target_compile_definitions(libYap PUBLIC  _XOPEN_SOURCE=700 )
 
 #add_definitions( -Wall  -Wstrict-prototypes -Wmissing-prototypes)
+set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -O0 -fno-omit-frame-pointer -fsanitize=address")
+set(CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address -fno-lto")
 
 # Model Specific
 set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS $<$<CONFIG:Debug>:DEBUG=1>)

--- a/CXX/yapdb.hh
+++ b/CXX/yapdb.hh
@@ -66,13 +66,16 @@ class X_API YAPModuleProp : public YAPProp {
   friend class YAPPredicate;
   ModEntry *m;
 
-  YAPModuleProp(ModEntry *mod) { m = mod; };
-  YAPModuleProp(Term tmod) { m = Yap_GetModuleEntry(tmod); };
+  YAPModuleProp(ModEntry *mod) { m = mod; }
+  YAPModuleProp(Term tmod) { m = Yap_GetModuleEntry(tmod); }
 
 public:
-  YAPModuleProp(YAPModule tmod) { m = Yap_GetModuleEntry(tmod.gt()); };
-  YAPModuleProp() { m = Yap_GetModuleEntry(Yap_CurrentModule()); };
-  virtual YAPModule module() { return YAPModule(m->AtomOfME); };
+  YAPModuleProp(YAPModule tmod) { m = Yap_GetModuleEntry(tmod.gt()); }
+  YAPModuleProp() { 
+    CACHE_REGS
+    m = Yap_GetModuleEntry(Yap_CurrentModule());
+  }
+  virtual YAPModule module() { return YAPModule(m->AtomOfME); }
 };
 
 /**
@@ -104,6 +107,7 @@ protected:
   ///
   /// It is just a call to getPred
   inline YAPPredicate(Term t, CELL *&v) {
+    CACHE_REGS
     if (t) {
       Term tm = Yap_CurrentModule();
       ap = getPred(t, tm, v);
@@ -111,6 +115,7 @@ protected:
   }
 
   inline YAPPredicate(Term t) {
+    CACHE_REGS
     if (t) {
       CELL *v = nullptr;
       Term tm = Yap_CurrentModule();
@@ -122,10 +127,12 @@ protected:
   ///
   /// It is just a call to getPred
   inline YAPPredicate(YAPTerm t, CELL *&v) {
+    CACHE_REGS
     Term tp = t.term(), tm = Yap_CurrentModule();
     ap = getPred(tp, tm, v);
   }
   inline YAPPredicate(YAPTerm t) {
+    CACHE_REGS
     CELL *v = nullptr;
     Term tp = t.term();
     Term tm = Yap_CurrentModule();
@@ -211,6 +218,7 @@ public:
   /// char */module constructor for predicates.
   ///
   inline YAPPredicate(const char *at, uintptr_t arity) {
+    CACHE_REGS
     ap = RepPredProp(PredPropByFunc(Yap_MkFunctor(Yap_LookupAtom(at), arity),
                                     Yap_CurrentModule()));
   };

--- a/CXX/yapie.hh
+++ b/CXX/yapie.hh
@@ -35,6 +35,7 @@ class X_API YAPError {
 public:
   /// wraps the default error descriptor
   YAPError() {
+    CACHE_REGS
     info = LOCAL_ActiveError;
     if (!info)
       LOCAL_ActiveError = info = (yap_error_descriptor_t *)calloc( sizeof( yap_error_descriptor_t ), 1);

--- a/CXX/yapt.hh
+++ b/CXX/yapt.hh
@@ -65,6 +65,7 @@ public:
   };
 
   void put(Term t0) {
+    CACHE_REGS
     Yap_PutInHandle(t, t0);
     // fprintf(stderr,"+%d,%lx,%p,%p",t,t0,HR,ASP); Yap_DebugPlWriteln(t0);
   };
@@ -132,8 +133,14 @@ public:
     return tf;
   };
 
-  inline void bind(Term b) { LOCAL_HandleBase[t] = b; }
-  inline void bind(YAPTerm *b) { LOCAL_HandleBase[t] = b->term(); }
+  inline void bind(Term b) {
+    CACHE_REGS
+    LOCAL_HandleBase[t] = b;
+  }
+  inline void bind(YAPTerm *b) {
+    CACHE_REGS
+    LOCAL_HandleBase[t] = b->term();
+  }
   /// from YAPTerm to Term (internal YAP representation)
   /// fetch a sub-term
   Term &operator[](arity_t n);
@@ -347,7 +354,7 @@ public:
 class X_API YAPIntegerTerm : public YAPNumberTerm {
 public:
   YAPIntegerTerm(intptr_t i);
-  intptr_t getInteger() { return IntegerOfTerm(gt()); };
+  intptr_t getInteger() { return IntegerOfTerm(gt()); }
 };
 
 /**
@@ -356,9 +363,12 @@ public:
 
 class X_API YAPFloatTerm : public YAPNumberTerm {
 public:
-  YAPFloatTerm(double dbl) { mk(MkFloatTerm(dbl)); };
+  YAPFloatTerm(double dbl) {
+    CACHE_REGS
+    mk(MkFloatTerm(dbl));
+  }
 
-  double getFl() { return FloatOfTerm(gt()); };
+  double getFl() { return FloatOfTerm(gt()); }
 };
 
 class X_API YAPListTerm : public YAPTerm {
@@ -473,7 +483,10 @@ class X_API YAPVarTerm : public YAPTerm {
 
 public:
   /// constructor
-  YAPVarTerm() { mk(MkVarTerm()); };
+  YAPVarTerm() {
+    CACHE_REGS
+    mk(MkVarTerm());
+  }
   /// get the internal representation
   CELL *getVar() { return VarOfTerm(gt()); }
   /// is the variable bound to another one

--- a/H/CMakeLists.txt
+++ b/H/CMakeLists.txt
@@ -1,9 +1,9 @@
 
 
 file( STRINGS locals.h tmp )
-if (WITH_THREADS)
+if (WITH_Threads)
     Foreach(i ${tmp})
-        string(REGEX REPLACE "^LOCAL[^(]*[(][^,]+,[^_a-zA-Z0-9]*([_a-zA-Z0-9]+)[^_a-zA-Z0-9,]*,[^_a-zA-Z0-9]*([_a-zA-Z0-9]+)[^)]*.*$"   "#define LOCAL_\\0 (Yap_regs.worker_local->\\1)\\n#define REMOTE_\\1(wid) (REMOTE(wid)->\\1)\\n" i2 ${i})
+	    string(REGEX REPLACE  "^LOCAL[^(]*[(][ \t]*([^,]+)[ \t]*,[ \t]*([^),]+).*"  "#define LOCAL_\\2 (Yap_REGS.worker_local_->\\2)\\n#define REMOTE_\\2(wid) (REMOTE(wid)->\\2)\\n" i2 ${i})
         list( APPEND tmp2 ${i2} "\n")
     endforeach()
 else()

--- a/H/Regs.h
+++ b/H/Regs.h
@@ -159,7 +159,7 @@ extern REGSTORE *Yap_regp;
 
 #ifdef PUSH_X
 
-#define XREGS  (Yapregp->XTERMS)
+#define XREGS  (Yap_regp->XTERMS)
 
 #else
 
@@ -570,8 +570,8 @@ INLINE_ONLY void restore_B(void) {
 #define PP	         (Yap_REGS.PP_)
 #if defined(YAPOR) || defined(THREADS)
 #define worker_id     (Yap_REGS.worker_id_)
-#define LOCAL	      (Yap_REGS.worker_local_)
-#define PREG_ADDR     (Yap_REGS.PREG_ADDR_)
+#define LOCAL	      Yap_REGS.worker_local_
+#define PREG_ADDR     Yap_REGS.PREG_ADDR_
 #ifdef YAPOR_SBA
 #define BSEG	      Yap_REGS.BSEG_
 #define binding_array Yap_REGS.binding_array_

--- a/H/Yap.h
+++ b/H/Yap.h
@@ -131,7 +131,9 @@ typedef YAP_handle_t yhandle_t;
 #endif /* TABLING || YAPOR_SBA */
 
 #if defined(THREADS) || defined(SUPPORT_CONDOR)
+#ifndef USE_SYSTEM_MALLOC
 #define USE_SYSTEM_MALLOC 1
+#endif /* USE_SYSTEM_MALLOC */
 #endif /* THREADS ||  SUPPORT_CONDOR */
 
 #if defined(ANALYST) && defined(USE_THREADED_CODE)

--- a/H/YapEval.h
+++ b/H/YapEval.h
@@ -436,6 +436,7 @@ extern Term Yap_InnerEval__(Term USES_REGS);
 
 static inline bool Yap_CheckArithError(void)
 {
+  CACHE_REGS
   bool on = false;
   yap_error_number err;
   if (LOCAL_Error_TYPE== RESOURCE_ERROR_STACK) {    

--- a/H/YapFlags.h
+++ b/H/YapFlags.h
@@ -119,6 +119,7 @@ INLINE_ONLY Term aro(Term inp) {
 // INLINE_ONLY Term booleanFlag( Term inp );
 
 static inline Term booleanFlag(Term inp) {
+  CACHE_REGS
   if (IsStringTerm(inp)) {
     inp = MkStringTerm(RepAtom(AtomOfTerm(inp))->StrOfAE);
   }
@@ -142,6 +143,7 @@ static inline Term booleanFlag(Term inp) {
 }
 
 static Term synerr(Term inp) {
+  CACHE_REGS
   if (IsStringTerm(inp)) {
     inp = MkStringTerm(RepAtom(AtomOfTerm(inp))->StrOfAE);
   }
@@ -173,6 +175,7 @@ static inline Term list_filler(Term inp) {
 // INLINE_ONLY  Term isatom( Term inp );
 
 static inline Term isatom(Term inp) {
+  CACHE_REGS
   if (IsVarTerm(inp)) {
     Yap_Error(INSTANTIATION_ERROR, inp, "set_prolog_flag %s",
               "value must be bound");

--- a/H/Yatom.h
+++ b/H/Yatom.h
@@ -1529,6 +1529,7 @@ extern bool Yap_HasException(void);
 extern yap_error_descriptor_t *Yap_GetException();
 extern void Yap_PrintException(yap_error_descriptor_t *i);
 INLINE_ONLY bool Yap_HasException(void) {
+  CACHE_REGS
   extern yap_error_number Yap_MathException__(USES_REGS1);
   yap_error_number me;
   if ((me = Yap_MathException__(PASS_REGS1)) && LOCAL_ActiveError->errorNo != YAP_NO_ERROR) {
@@ -1538,6 +1539,7 @@ INLINE_ONLY bool Yap_HasException(void) {
 }
 
 INLINE_ONLY Term MkSysError(yap_error_descriptor_t *i) {
+  CACHE_REGS
   Term et = MkAddressTerm(i);
   return Yap_MkApplTerm(FunctorException, 1, &et);
 }

--- a/H/alloc.h
+++ b/H/alloc.h
@@ -197,8 +197,8 @@ extern void *Realloc(void *buf, size_t sz USES_REGS);
 extern void Free(void *buf USES_REGS);
 
 extern void *MallocAtLevel(size_t sz, int atL USES_REGS);
-#define BaseMalloc(sz) MallocAtLevel(sz, 1)
-extern const void *MallocExportAsRO(const void *blk);
+#define BaseMalloc(sz) MallocAtLevel(sz, 1 PASS_REGS)
+extern const void *MallocExportAsRO(const void *blk USES_REGS);
 
 
 #define MBYTE (1024 * 1024)

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -38,12 +38,12 @@
 
 /* Are we compiling with support for threads? */
 #ifndef THREADS
-#cmakedefine THREADS  "$YAP_THREADS"
+#cmakedefine THREADS  ${YAP_THREADS}
 #endif
 
 /* Are we compiling with support for clause just-in-time compilationT? */
 #ifndef YAP_JIT
-#cmakedefine YAP_JIT  "$YAP_JIT"
+#cmakedefine YAP_JIT  "${YAP_JIT}"
 #endif
 
 /* longs should be in addresses that are multiple of four. */

--- a/include/YapUTF8.h
+++ b/include/YapUTF8.h
@@ -43,6 +43,7 @@ INLINE_ONLY utf8proc_ssize_t get_utf8(const utf8proc_uint8_t *ptr,
 INLINE_ONLY utf8proc_ssize_t get_utf8(const utf8proc_uint8_t *ptr,
                                                     size_t n,
                                                     utf8proc_int32_t *valp) {
+  CACHE_REGS
      utf8proc_ssize_t rc = utf8proc_iterate(ptr, n, valp);
   if (rc <= 0) {
       if (ptr[0] == 0xC0 && ptr[1] == 0x80) {
@@ -59,6 +60,7 @@ INLINE_ONLY utf8proc_ssize_t put_utf8(utf8proc_uint8_t *ptr,
 
 INLINE_ONLY utf8proc_ssize_t put_xutf8(utf8proc_uint8_t *ptr,
                                                     utf8proc_int32_t val) {
+    CACHE_REGS
     if (val == 0) {
         ptr[0] = 0xC0;
         ptr[1] = 0x80;
@@ -75,6 +77,7 @@ INLINE_ONLY utf8proc_ssize_t put_xutf8(utf8proc_uint8_t *ptr,
 
 INLINE_ONLY utf8proc_ssize_t put_utf8(utf8proc_uint8_t *ptr,
                                        utf8proc_int32_t val) {
+    CACHE_REGS
     utf8proc_ssize_t rc = utf8proc_encode_char(val, ptr);
     if (rc <= 0) {
 

--- a/os/charsio.c
+++ b/os/charsio.c
@@ -113,6 +113,7 @@ static int oops_c_from_w(int sno)
 }
 
 int Yap_peekWide(int sno) {
+  CACHE_REGS
   StreamDesc *s = GLOBAL_Stream + sno;
   int ch;
       Int pos = s->charcount;
@@ -133,7 +134,7 @@ int Yap_peekWide(int sno) {
      if (ch == EOF) {
           s->status &= ~Eof_Error_Stream_f;
       } else if (s->status & Seekable_Stream_f) {
-        Yap_SetCurInpPos(sno, pos);
+        Yap_SetCurInpPos(sno, pos PASS_REGS);
       } else {
         s->buf.on = true;
         s->buf.ch = ch;
@@ -467,7 +468,7 @@ code with  _C_. A byte is represented as either a number between 1 and 255, or a
 
 
 */
-static Int get_byte(USES_REGS) { /* '$get_byte'(Stream,-N) */
+static Int get_byte(USES_REGS1) { /* '$get_byte'(Stream,-N) */
   Term out = Deref(ARG2);
 
   if (!IsVarTerm(out)) {

--- a/os/console.c
+++ b/os/console.c
@@ -43,6 +43,7 @@ static int ConsolePutc(int, int);
 
 
 bool Yap_DoPrompt(StreamDesc *s) {
+  CACHE_REGS
   if (s->status & Tty_Stream_f) {
     if (GLOBAL_Stream[LOCAL_c_input_stream].status & Tty_Stream_f &&
 	GLOBAL_Stream[LOCAL_c_error_stream].status & Tty_Stream_f) {
@@ -55,6 +56,7 @@ bool Yap_DoPrompt(StreamDesc *s) {
 
 /* check if we read a newline or an EOF */
 int console_post_process_read_char(int ch, StreamDesc *s) {
+  CACHE_REGS
   /* the character is also going to be output by the console handler */
   console_count_output_char(ch, GLOBAL_Stream + LOCAL_c_error_stream);
   if (ch == '\r') {
@@ -62,13 +64,11 @@ int console_post_process_read_char(int ch, StreamDesc *s) {
     LOCAL_newline = true;
 } else
  if (ch == '\n') {
-    CACHE_REGS
     ++s->linecount;
     ++s->charcount;
     s->linepos = 0;
     LOCAL_newline = true;
   } else {
-    CACHE_REGS
     ++s->charcount;
     ++s->linepos;
     LOCAL_newline = false;
@@ -77,6 +77,7 @@ int console_post_process_read_char(int ch, StreamDesc *s) {
 }
 
 bool is_same_tty(FILE *f1, FILE *f2) {
+  CACHE_REGS
 #if HAVE_TTYNAME
   return ttyname_r(fileno(f1), LOCAL_FileNameBuf, YAP_FILENAME_MAX - 1) ==
          ttyname_r(fileno(f2), LOCAL_FileNameBuf, YAP_FILENAME_MAX - 1);
@@ -111,6 +112,7 @@ void Yap_ConsoleOps(StreamDesc *s) {
 
 /* static */
 static int ConsolePutc(int sno, int ch) {
+  CACHE_REGS
   StreamDesc *s = &GLOBAL_Stream[sno];
   if (ch == 10) {
 #if MAC || _WIN32

--- a/os/files.c
+++ b/os/files.c
@@ -376,9 +376,10 @@ static Int exists_directory(USES_REGS1) {
     VFS_t *vfs;
     if (!s) return false;
     if ((vfs = vfs_owner(s))) {
-bool rc = true;
-      return vfs->isdir(vfs, s);
-
+      Int sno = Yap_CheckStream(ARG1, (Input_Stream_f | Output_Stream_f | Socket_Stream_f), 
+                                "exists_directory/1");
+      if (sno < 0) return false;
+      bool rc = vfs->isdir(vfs, s);
       UNLOCK(GLOBAL_Stream[sno].streamlock);
       return rc;
     }
@@ -516,7 +517,7 @@ Create a directory  _Yap_Dir_. If the parent directory does not exist, silently 
 static Int make_directory(USES_REGS1) {
   int lvl = push_text_stack();
   const char *fd0 = Yap_AbsoluteFile(Yap_TextTermToText(Deref(ARG1) PASS_REGS),true);
-  char *fd = Malloc(strlen(fd0)+1);
+  char *fd = Malloc(strlen(fd0)+1 PASS_REGS);
   strcpy( fd, fd0);
   char *s = (char *)skip_root(fd), *ns;
   int ch;
@@ -648,6 +649,9 @@ static Int access_path(USES_REGS1) {
         if (!s) return false;
         if ((vfs = vfs_owner(s))) {
             vfs_stat st;
+            Int sno = Yap_CheckStream(ARG1, (Input_Stream_f | Output_Stream_f | Socket_Stream_f), 
+                                      "access");
+            if (sno < 0) return false;
             bool rc = vfs->stat(vfs, s, &st);
             UNLOCK(GLOBAL_Stream[sno].streamlock);
             return rc;
@@ -751,6 +755,9 @@ static Int exists_file(USES_REGS1) {
         char *s =  RepAtom(AtomOfTerm(tname))->StrOfAE;
         if (!s) return false;
         if ((vfs = vfs_owner(s))) {
+            Int sno = Yap_CheckStream(ARG1, (Input_Stream_f | Output_Stream_f | Socket_Stream_f), 
+                                      "exists_file/1");
+            if (sno < 0) return false;
             vfs_stat st;
             bool rc = vfs->stat(vfs, s, &st);
             UNLOCK(GLOBAL_Stream[sno].streamlock);

--- a/os/fmem.c
+++ b/os/fmem.c
@@ -31,7 +31,8 @@ static char SccsId[] = "%W% %G%";
 #include "YapText.h"
 
  char *Yap_StrPrefix( const char *buf, size_t n) {
-    char *b = Malloc(n);
+    CACHE_REGS
+    char *b = Malloc(n PASS_REGS);
     strncpy(b, buf, n - 1);
     if (strlen(buf) > n - 1)
         b[15] = '\0';
@@ -183,7 +184,7 @@ open_mem_read_stream(USES_REGS1) /* $open_mem_read_stream(+List,-Stream) */
 
   ti = Deref(ARG1);
   int l = push_text_stack();
-  buf = Yap_TextTermToText(ti);
+  buf = Yap_TextTermToText(ti PASS_REGS);
   if (!buf) {
     pop_text_stack(l);
     return false;

--- a/os/format.c
+++ b/os/format.c
@@ -361,6 +361,7 @@ static Int format_copy_args(Term args, Term *targs, Int tsz) {
 static void
 
 format_clean_up(int sno, int sno0, format_info *finfo) {
+  CACHE_REGS
   if (sno >= 0 && sno != sno0) {
     sno = format_synch(sno, sno0, finfo);
     Yap_CloseStream(sno);
@@ -412,8 +413,8 @@ static Int doformat(volatile Term otail, volatile Term oargs,
   bool alloc_fstr = false;
   LOCAL_Error_TYPE = YAP_NO_ERROR;
   int l = push_text_stack();
-  tmp1 = Malloc(TMP_STRING_SIZE+1);
-  format_info *finfo = Malloc(sizeof(format_info));
+  tmp1 = Malloc(TMP_STRING_SIZE+1 PASS_REGS);
+  format_info *finfo = Malloc(sizeof(format_info) PASS_REGS);
   // it starts here
   finfo->gapi = 0;
   finfo->phys_start = 0;
@@ -449,7 +450,7 @@ static Int doformat(volatile Term otail, volatile Term oargs,
     format_clean_up(sno0, sno, finfo );
     Yap_ThrowError(INSTANTIATION_ERROR, tail, "format/2");
     return (FALSE);
-  } else if ((fstr = Yap_TextToUTF8Buffer(tail))) {
+  } else if ((fstr = Yap_TextToUTF8Buffer(tail PASS_REGS))) {
     fptr = fstr;
     alloc_fstr = true;
   } else {
@@ -488,7 +489,7 @@ static Int doformat(volatile Term otail, volatile Term oargs,
   if (IsPairTerm(args)) {
     Int tsz = 16;
 
-    targs = Malloc(32*sizeof(Term));
+    targs = Malloc(32*sizeof(Term) PASS_REGS);
     do {
       tnum = format_copy_args(args, targs, tsz);
       if (tnum == FORMAT_COPY_ARGS_ERROR ||
@@ -499,13 +500,13 @@ static Int doformat(volatile Term otail, volatile Term oargs,
       }
       else if (tnum == tsz ) {
 	tnum += 32;
-	targs = Realloc(targs, tnum*sizeof(Term));
+	targs = Realloc(targs, tnum*sizeof(Term) PASS_REGS);
       }
       break;
     } while (true);      
   } else if (args != TermNil) {
     tnum = 1;
-     targs = Malloc(sizeof(Term));
+     targs = Malloc(sizeof(Term) PASS_REGS);
      targs[0] = args;
   } else {
     tnum = 0;
@@ -1041,6 +1042,7 @@ static Int doformat(volatile Term otail, volatile Term oargs,
 }
 
 static Term memStreamToTerm(int output_stream, Functor f, Term inp) {
+  CACHE_REGS
   const char *s = Yap_MemExportStreamPtr(output_stream);
 
   encoding_t enc = GLOBAL_Stream[output_stream].encoding;

--- a/os/iopreds.c
+++ b/os/iopreds.c
@@ -184,6 +184,7 @@ static int EOFGetc(int sno) {
 }
 
 static void unix_upd_stream_info(StreamDesc *s) {
+  CACHE_REGS
   if (s->status & InMemory_Stream_f) {
     s->status |= Seekable_Stream_f;
     return;
@@ -413,6 +414,7 @@ void Yap_InitStdStreams(void) { InitStdStreams(); }
 
 Int PlIOError__(const char *file, const char *function, int lineno,
                 yap_error_number type, Term culprit, ...) {
+  CACHE_REGS
   if (trueLocalPrologFlag(FILEERRORS_FLAG) ||
       type == RESOURCE_ERROR_MAX_STREAMS /* do not catch resource errors */) {
     va_list args;
@@ -440,10 +442,11 @@ Int PlIOError__(const char *file, const char *function, int lineno,
 bool
  UnixIOError__(const char *file, const char *function, int lineno,
                 int error, io_kind_t io_type, Term culprit, ...) {
+  CACHE_REGS
   if (trueLocalPrologFlag(FILEERRORS_FLAG) ) {
     va_list args;
     const char *format;
-    char *who = Malloc(1024);
+    char *who = Malloc(1024 PASS_REGS);
     yap_error_number e_type;
 
     va_start(args, culprit);
@@ -1127,6 +1130,7 @@ static int check_bom(int sno, StreamDesc *st) {
 bool Yap_initStream(int sno, FILE *fd, Atom name, const char *io_mode,
                     Term file_name, encoding_t encoding, stream_flags_t flags,
                     void *vfs) {
+  CACHE_REGS
   // fprintf(stderr,"+ %s --> %d\n", name, sno);
   StreamDesc *st = &GLOBAL_Stream[sno];
   __android_log_print(
@@ -1321,6 +1325,7 @@ static const param_t open_defs[] = {OPEN_DEFS()};
 
 static bool fill_stream(int sno, StreamDesc *st, Term tin, const char *io_mode,
                         Term user_name, encoding_t enc) {
+  CACHE_REGS
   struct vfs *vfsp = NULL;
   const char *fname;
 

--- a/os/readutil.c
+++ b/os/readutil.c
@@ -50,7 +50,7 @@ static Int rl_to_codes(Term TEnd, int do_as_binary, int arity USES_REGS) {
     UNLOCK(GLOBAL_Stream[sno].streamlock);
     return Yap_unify_constant(ARG2, MkAtomTerm(AtomEof));
   }
-          buf = Malloc(4096);
+          buf = Malloc(4096 PASS_REGS);
   buf_sz = 4096;
   while (true) {
     if (do_as_binary && !binary_stream) {

--- a/os/streams.c
+++ b/os/streams.c
@@ -336,6 +336,7 @@ bool Yap_SetCurInpPos(
 }
 
 Atom Yap_guessFileName(FILE *file, int sno, size_t max) {
+  CACHE_REGS
   if (!file) {
     Atom at = Yap_LookupAtom("mem");
     return at;
@@ -349,7 +350,7 @@ Atom Yap_guessFileName(FILE *file, int sno, size_t max) {
   int i = push_text_stack();
 #if __linux__
   size_t maxs = Yap_Max(1023, max - 1);
-  char *path = Malloc(1024), *nameb = Malloc(maxs + 1);
+  char *path = Malloc(1024 PASS_REGS), *nameb = Malloc(maxs + 1 PASS_REGS);
   size_t len;
   if ((len = snprintf(path, 1023, "/proc/self/fd/%d", f)) >= 0 &&
       (len = readlink(path, nameb, maxs)) > 0) {
@@ -1124,6 +1125,7 @@ static Int current_input(USES_REGS1) { /* current_input(?Stream) */
 }
 
 bool Yap_SetInputStream(Term sd) {
+  CACHE_REGS
   int sno = Yap_CheckStream(sd, Input_Stream_f, "set_input/1");
   if (sno < 0)
     return false;
@@ -1202,6 +1204,7 @@ bool Yap_SetOutputStream(Term sd) {
 }
 
 bool Yap_SetErrorStream(Term sd) {
+  CACHE_REGS
   int sno =
       Yap_CheckStream(sd, Output_Stream_f | Append_Stream_f, "set_error/2");
   if (sno < 0)

--- a/os/sysbits.c
+++ b/os/sysbits.c
@@ -194,6 +194,7 @@ static char *unix2win(const char *source, char *target, int max) {
 extern char *virtual_cwd;
 
 bool Yap_ChDir(const char *path) {
+  CACHE_REGS
   bool rc = false;
   int lvl = push_text_stack();
 
@@ -788,7 +789,7 @@ void Yap_InitSysbits(int wid) {
   Yap_InitWTime();
   Yap_InitRandom();
   /* let the caller control signals as it sees fit */
-  Yap_InitOSSignals(worker_id);
+  Yap_InitOSSignals(wid);
 }
 
 static Int p_unix(USES_REGS1) {
@@ -1074,6 +1075,7 @@ static Int
   p_mtrace()
   {
 #ifdef HAVE_MTRACE
+    CACHE_REGS
     Term t = Deref(ARG1);
     if (t == TermTrue) mtrace();
     else if (t == TermFalse)  muntrace();

--- a/os/writeterm.c
+++ b/os/writeterm.c
@@ -619,7 +619,7 @@ static Int term_to_atom(USES_REGS1) {
   if (IsVarTerm(t2)) {
     const char *s =
         Yap_TermToBuffer(Deref(ARG1), Quote_illegal_f | Handle_vars_f);
-    if (!s || !(at = Yap_UTF8ToAtom((const unsigned char *)s))) {
+    if (!s || !(at = Yap_UTF8ToAtom((const unsigned char *)s PASS_REGS))) {
       Yap_Error(RESOURCE_ERROR_HEAP, t2,
                 "Could not get memory from the operating system");
       return false;

--- a/packages/myddas/myddas_shared.c
+++ b/packages/myddas/myddas_shared.c
@@ -51,6 +51,7 @@ static Int c_db_check(USES_REGS1);
 #endif
 
 void Yap_InitMYDDAS_SharedPreds(void) {
+  CACHE_REGS
   Term cm = CurrentModule;
   CurrentModule = MkAtomTerm(Yap_LookupAtom("myddas"));
   /* c_db_initialize_myddas */
@@ -92,6 +93,7 @@ void Yap_InitMYDDAS_SharedPreds(void) {
 }
 
 void Yap_InitBackMYDDAS_SharedPreds(void) {
+  CACHE_REGS
   Term cm = CurrentModule;
   CurrentModule = MkAtomTerm(Yap_LookupAtom("myddas"));
   /* Gives all the predicates associated to a given connection */

--- a/packages/python/pl2py.c
+++ b/packages/python/pl2py.c
@@ -118,6 +118,7 @@ X_API PyObject *string_to_python(const char *s, bool eval, PyObject *p0) {
 
 static bool entry_to_dictionary(PyObject *dict, Term targ,
                                bool eval, bool cvt) {
+  CACHE_REGS
   PyObject *lhs = NULL, *rhs;
   Term t1, t2;
   const char *s;
@@ -156,6 +157,7 @@ static bool entry_to_dictionary(PyObject *dict, Term targ,
  */
 PyObject *term_to_python(term_t t, bool eval, PyObject *o, bool cvt) {
   //
+  CACHE_REGS
   switch (PL_term_type(t)) {
   case PL_VARIABLE: {
     if (t == 0) {
@@ -452,6 +454,7 @@ PyObject *deref_term_to_python(term_t t) {
 }
 
   PyObject *yap_to_python(Term t, bool eval, PyObject *o, bool cvt) {
+    CACHE_REGS
     if (t == 0 || t == TermNone)
         return Py_None;
     //  fprintf(stderr,"RS %ld %s:%d\n", LOCAL_CurHandle, __FILE__, __LINE__);

--- a/packages/python/py2pl.c
+++ b/packages/python/py2pl.c
@@ -33,6 +33,7 @@ void YAPPy_ThrowError__(const char *file, const char *function, int lineno,
 }
 
 static Term repr_term(PyObject *pVal) {
+  CACHE_REGS
   Term t = MkAddressTerm(pVal);
   return Yap_MkApplTerm(FunctorObj, 1, &t);
 }
@@ -52,6 +53,7 @@ foreign_t assign_to_symbol(term_t t, PyObject *e) {
 }
 
 static Term python_to_term__(PyObject *pVal) {
+  CACHE_REGS
   if (pVal == Py_None) {
     // fputs("<<*** ",stderr);Yap_DebugPlWrite(YAP_GetFromSlot(t));   fputs("
     // >>***\n",stderr);
@@ -195,6 +197,7 @@ foreign_t python_to_term(PyObject *pVal, term_t t) {
 // extern bool Yap_do_low_level_trace;
 
 X_API YAP_Term pythonToYAP(PyObject *pVal) {
+  CACHE_REGS
   // Yap_do_low_level_trace=1;
   /* fputs(" ***    ", stderr); */
   /* PyObject_Print(pVal, stderr, 0); */
@@ -231,6 +234,7 @@ PyObject *py_Local, *py_Global;
  *pythonfind_assign.
  */
 bool python_assign(term_t t, PyObject *exp, PyObject *context) {
+  CACHE_REGS
   PyErr_Print();
   // Yap_DebugPlWriteln(yt);
   if (PL_term_type(t) == PL_VARIABLE) {

--- a/packages/python/py4yap.h
+++ b/packages/python/py4yap.h
@@ -1,12 +1,6 @@
 
-#undef PASS_REGS
-#undef USES_REGS
-
 #ifndef PY4YAP_H
 #define PY4YAP_H 1
-
-#define PASS_REGS
-#define USES_REGS
 
 #include "Yap.h"
 
@@ -136,6 +130,7 @@ static inline int proper_ascii_string(const char *s) {
 }
 
 static inline PyObject *atom_to_python_string(term_t t) {
+  CACHE_REGS
   // Yap_DebugPlWrite(YAP_GetFromSlot(t));        fprintf(stderr, " here I
   // am\n");
   const char *s = NULL;

--- a/packages/python/pybips.c
+++ b/packages/python/pybips.c
@@ -118,6 +118,7 @@ PyObject *PythonLookup(const char *s, PyObject *oo) {
 PyObject *
 
 find_obj(PyObject* ctx, PyObject *exp, term_t t, bool eval) {
+    CACHE_REGS
     YAP_Term hd, yt;
     py_Context = ctx;
 // Yap_DebugPlWriteln(yt);
@@ -803,6 +804,7 @@ static PyObject *bip_range(term_t t) {
 
 
 PyObject *compound_to_pytree(term_t t, PyObject *context, bool cvt) {
+  CACHE_REGS
   PyObject *o = py_Main;
   functor_t fun;
   atom_t name;
@@ -866,6 +868,7 @@ PyObject *compound_to_pytree(term_t t, PyObject *context, bool cvt) {
 }
 
 PyObject *compound_to_pyeval(term_t t, PyObject *context, bool cvt) {
+  CACHE_REGS
   PyObject *o = NULL;
   atom_t name;
 size_t arity;

--- a/packages/python/pypreds.c
+++ b/packages/python/pypreds.c
@@ -603,6 +603,7 @@ static foreign_t python_export(term_t t, term_t pl) {
  * @return       success?
  */
 static int python_import(term_t mname, term_t mod) {
+  CACHE_REGS
   PyObject *pName;
   foreign_t do_as = false;
   PyStart();

--- a/packages/python/python.c
+++ b/packages/python/python.c
@@ -15,8 +15,6 @@
 #include "py4yap.h"
 #include <VFS.h>
 
-#define USES_REGS
-
 #include "YapStreams.h"
 
 atom_t ATOM_true, ATOM_false, ATOM_colon, ATOM_dot, ATOM_none, ATOM_t,


### PR DESCRIPTION
The changes include:

1. Fixing CMake configuration of `LOCAL_*` macros.
2. Fixing preprocessor errors.
3. Fixing compiler errors caused by incorrect register passing.
4. Fixing compiler errors and warnings caused by typos and incorrect name references.

With these changes, I am compiling YAP on Ubuntu Focal with CMake 3.16.3 and GCC 10.0.1 with the following commands:

> cmake -G "Unix Makefiles" -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DTHREADS=1 -DYAP_THREADS=1 -DWITH_Threads=ON -DWITH_MAX_Threads=1024 -DWITH_MAX_Workers=64 -DCMAKE_BUILD_TYPE=Debug -S . -B build
>  
> cmake --build build

Some optional packages are not installed:

> -- Packages not found:
> * SWIG
> * CUDD
> * LibR
> * LibXml2
> * PkgConfig
> * RAPTOR
> * Gecode
> * Java

Before this PR is ready for review, I will need to fix (at least) a segfault that occurs when CMake launches the yap binary to generate a startup.yss file. Here's the gdb backtrace:

> Program received signal SIGSEGV, Segmentation fault.
0x00007ffff76148b0 in ?? () from /lib/x86_64-linux-gnu/libasan.so.6
(gdb) bt
#0  0x00007ffff76148b0 in ?? () from /lib/x86_64-linux-gnu/libasan.so.6
#1  0x00007ffff769c69d in realloc () from /lib/x86_64-linux-gnu/libasan.so.6
#2  0x00007ffff73a687f in ensure_slots (regcache=0x7ffff75ea580 <Yap_standard_regs>, N=1)
    at /target/yap-6.3/H/YapHandles.h:192
#3  Yap_InitHandle__ (regcache=0x7ffff75ea580 <Yap_standard_regs>, t=106034152604129)
    at /target/yap-6.3/H/YapHandles.h:219
#4  Yap_read_term (sno=3, opts=106034152604129, clause=false) at /target/yap-6.3/os/readterm.c:1248
#5  0x00007ffff73a9e8b in Yap_BufferToTerm (s=0x7ffff745e020 "false", opts=106034152604129)
    at /target/yap-6.3/os/readterm.c:1707
#6  0x00007ffff73aa2d0 in Yap_BufferToTermWithPrioBindings (s=0x7ffff745e020 "false",
    ctl=106034152604129, bindings=0, len=6, prio=1200) at /target/yap-6.3/os/readterm.c:1740
#7  0x00007ffff702fbe4 in setInitialValue (bootstrap=false, f=0x7ffff701a853 <ro>,
    s=0x7ffff745e020 "false", tarr=0x61b0000000a0) at /target/yap-6.3/C/flags.c:1541
#8  0x00007ffff7035487 in Yap_InitFlags (bootstrap=false) at /target/yap-6.3/C/flags.c:1876
#9  0x00007ffff70ee1d9 in InitStdPreds (yapi=0x7fffffffdda0) at /target/yap-6.3/C/init.c:1007
#10 0x00007ffff710a5fe in Yap_InitWorkspace (yapi=0x7fffffffdda0, Heap=140737488348640, Stack=8192,
    Trail=4096, Atts=0, max_table_size=0, n_workers=0, sch_loop=0, delay_load=0)
    at /target/yap-6.3/C/init.c:1455
#11 0x00007ffff72aeed3 in YAP_Init (yap_init=0x7fffffffdda0) at /target/yap-6.3/C/yap-args.c:1147
#12 0x00005555555565a5 in init_standard_system (argc=1, argv=0x7fffffffe708, iap=0x7fffffffdda0)
    at /target/yap-6.3/console/yap.c:80
#13 0x000055555555683e in main (argc=1, argv=0x7fffffffe708) at /target/yap-6.3/console/yap.c:128

The segfault occurs because `ensure_slots()` attempts to reallocate `LOCAL_HandleBase`, an alias for `LOCAL_SlotBase`, which has the erroneous value `0x400`. I have confirmed that `LOCAL_SlotBase` is initialized properly and has the correct value just before the call to `Yap_BufferToTermWithPrioBindings()` at frame 6 of the backtrace.
